### PR TITLE
ensures the repository is not shallow

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: run Github Super-linter
         uses: github/super-linter@v6


### PR DESCRIPTION
This change ensures the repository is not shallow and all commits (including the one referenced by GITHUB_SHA) are available during the workflow run.